### PR TITLE
Add typical Ember-CLI full path to source example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pre {
 ## Available Options
 - `browsers` - `Array` - an array of [browsers and versions to support](https://github.com/postcss/autoprefixer#browsers).
 - `compress` - `Boolean` - whether to compress the CSS output.
-- `source` - `String` - the full path to the source CSS file. This is necessary if you want Myth to concatenate `@import` rules in your CSS.
+- `source` - `String` - the full path to the source CSS file. This is necessary if you want Myth to concatenate `@import` rules in your CSS. Usually: `./app/styles/app.css`
 - `features` - `Object` - any features you'd like to disable. All features are enabled by default. For example:
 ```js
 features: {


### PR DESCRIPTION
After two hours of debugging what "full path" actually means, I feel like this is an important piece of documentation for ember-myth. _Any_ other format of path for this option leads to "file not found" errors. Others [have also](http://discuss.emberjs.com/t/broccoli-frustrations/6872) had issues with this previously.
