### PR TITLE
Remove console.log

### DIFF
--- a/lib/broccoli-myth.js
+++ b/lib/broccoli-myth.js
@@ -42,7 +42,6 @@ MythCompiler.prototype.updateCache = function (srcDir, destDir) {
 	mkdirp.sync(path.dirname(destFile));
 
 	return readFile(mythOptions.filename, { encoding: 'utf8' }).then(function (input) {
-		console.log(input);
 		return writeFile(destFile, myth(input, mythOptions).trim(), { encoding: 'utf8' });
 	});
 }


### PR DESCRIPTION
Removes the output during ember build.  If this was on purpose I'm happy to do the work to put this behind an option.
